### PR TITLE
Implement a set of new mesh wrapping algorithms for extra performance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "pptree",
     "rod >= 0.3.0",
     "typing_extensions ; python_version < '3.12'",
+    "trimesh",
 ]
 
 [project.optional-dependencies]
@@ -64,6 +65,8 @@ testing = [
     "pytest >=6.0",
     "pytest-icdiff",
     "robot-descriptions",
+    "networkx",
+    "lark"
 ]
 viz = [
     "lxml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "rod >= 0.3.0",
     "typing_extensions ; python_version < '3.12'",
     "trimesh",
+    "manifold3d",
 ]
 
 [project.optional-dependencies]

--- a/src/jaxsim/parsers/rod/meshes.py
+++ b/src/jaxsim/parsers/rod/meshes.py
@@ -1,0 +1,80 @@
+import trimesh
+import numpy as np
+
+
+def extract_points_vertex_extraction(mesh: trimesh.Trimesh) -> np.ndarray:
+    """Extracts the points of a mesh using the vertices of the mesh as colliders.
+
+    Args:
+        mesh: The mesh to extract the points from.
+
+    Returns:
+        The points of the mesh.
+    """
+    return mesh.vertices
+
+
+def extract_points_random_surface_sampling(
+    mesh: trimesh.Trimesh, num_points: int
+) -> np.ndarray:
+    """Extracts the points of a mesh by sampling the surface of the mesh randomly.
+
+    Args:
+        mesh: The mesh to extract the points from.
+        num_points: The number of points to sample.
+
+    Returns:
+        The points of the mesh.
+    """
+    return mesh.sample(num_points)
+
+
+def extract_points_uniform_surface_sampling(
+    mesh: trimesh.Trimesh, num_points: int
+) -> np.ndarray:
+    """Extracts the points of a mesh by sampling the surface of the mesh uniformly.
+
+    Args:
+        mesh: The mesh to extract the points from.
+        num_points: The number of points to sample.
+
+    Returns:
+        The points of the mesh.
+    """
+    return trimesh.sample.sample_surface_even(mesh=mesh, count=num_points)
+
+
+def extract_points_aap(
+    mesh: trimesh.Trimesh,
+    aap_axis: str,
+    aap_value: float,
+    aap_direction: str,
+) -> np.ndarray:
+    """Extracts the points of a mesh that are on one side of an axis-aligned plane (AAP).
+
+    Args:
+        mesh: The mesh to extract the points from.
+        aap_axis: The axis of the AAP.
+        aap_value: The value of the AAP.
+        aap_direction: The direction of the AAP.
+
+    Returns:
+        The points of the mesh that are on one side of the AAP.
+    """
+    if aap_direction == "higher":
+        aap_operator = np.greater
+    elif aap_direction == "lower":
+        aap_operator = np.less
+    else:
+        raise ValueError("Invalid direction for axis-aligned plane")
+
+    if aap_axis == "x":
+        points = mesh.vertices[aap_operator(mesh.vertices[:, 0], aap_value)]
+    elif aap_axis == "y":
+        points = mesh.vertices[aap_operator(mesh.vertices[:, 1], aap_value)]
+    elif aap_axis == "z":
+        points = mesh.vertices[aap_operator(mesh.vertices[:, 2], aap_value)]
+    else:
+        raise ValueError("Invalid axis for axis-aligned plane")
+
+    return points

--- a/src/jaxsim/parsers/rod/meshes.py
+++ b/src/jaxsim/parsers/rod/meshes.py
@@ -1,80 +1,202 @@
 import trimesh
 import numpy as np
+import rod
 
 
-def extract_points_vertex_extraction(mesh: trimesh.Trimesh) -> np.ndarray:
-    """Extracts the points of a mesh using the vertices of the mesh as colliders.
-
-    Args:
-        mesh: The mesh to extract the points from.
-
-    Returns:
-        The points of the mesh.
-    """
-    return mesh.vertices
-
-
-def extract_points_random_surface_sampling(
-    mesh: trimesh.Trimesh, num_points: int
-) -> np.ndarray:
-    """Extracts the points of a mesh by sampling the surface of the mesh randomly.
-
-    Args:
-        mesh: The mesh to extract the points from.
-        num_points: The number of points to sample.
-
-    Returns:
-        The points of the mesh.
-    """
-    return mesh.sample(num_points)
-
-
-def extract_points_uniform_surface_sampling(
-    mesh: trimesh.Trimesh, num_points: int
-) -> np.ndarray:
-    """Extracts the points of a mesh by sampling the surface of the mesh uniformly.
-
-    Args:
-        mesh: The mesh to extract the points from.
-        num_points: The number of points to sample.
-
-    Returns:
-        The points of the mesh.
-    """
-    return trimesh.sample.sample_surface_even(mesh=mesh, count=num_points)
-
-
-def extract_points_aap(
-    mesh: trimesh.Trimesh,
-    aap_axis: str,
-    aap_value: float,
-    aap_direction: str,
-) -> np.ndarray:
-    """Extracts the points of a mesh that are on one side of an axis-aligned plane (AAP).
-
-    Args:
-        mesh: The mesh to extract the points from.
-        aap_axis: The axis of the AAP.
-        aap_value: The value of the AAP.
-        aap_direction: The direction of the AAP.
-
-    Returns:
-        The points of the mesh that are on one side of the AAP.
-    """
-    if aap_direction == "higher":
-        aap_operator = np.greater
-    elif aap_direction == "lower":
-        aap_operator = np.less
+def parse_object_mapping_object(obj) -> trimesh.Trimesh:
+    if isinstance(obj, trimesh.Trimesh):
+        return obj
+    elif isinstance(obj, dict):
+        if "type" not in obj:
+            raise ValueError("Object type not specified")
+        if obj["type"] == "box":
+            if "extents" not in obj:
+                raise ValueError("Box extents not specified")
+            return trimesh.creation.box(extents=obj["extents"])
+        elif obj["type"] == "sphere":
+            if "radius" not in obj:
+                raise ValueError("Sphere radius not specified")
+            return trimesh.creation.icosphere(subdivisions=4, radius=obj["radius"])
+        else:
+            raise ValueError(f"Invalid object type {obj['type']}")
+    elif isinstance(obj, rod.builder.primitive_builder.PrimitiveBuilder):
+        raise NotImplementedError("PrimitiveBuilder not implemented")
     else:
-        raise ValueError("Invalid direction for axis-aligned plane")
+        raise ValueError("Invalid object type")
 
-    if aap_axis == "x":
-        points = mesh.vertices[aap_operator(mesh.vertices[:, 0], aap_value)]
-    elif aap_axis == "y":
-        points = mesh.vertices[aap_operator(mesh.vertices[:, 1], aap_value)]
-    elif aap_axis == "z":
-        points = mesh.vertices[aap_operator(mesh.vertices[:, 2], aap_value)]
-    else:
-        raise ValueError("Invalid axis for axis-aligned plane")
 
-    return points
+class MeshMapping:
+    @staticmethod
+    def vertex_extraction(mesh: trimesh.Trimesh) -> np.ndarray:
+        """Extracts the points of a mesh using the vertices of the mesh as colliders.
+
+        Args:
+            mesh: The mesh to extract the points from.
+
+        Returns:
+            The points of the mesh.
+        """
+        return mesh.vertices
+
+    @staticmethod
+    def random_surface_sampling(mesh: trimesh.Trimesh, num_points: int) -> np.ndarray:
+        """Extracts the points of a mesh by sampling the surface of the mesh randomly.
+
+        Args:
+            mesh: The mesh to extract the points from.
+            num_points: The number of points to sample.
+
+        Returns:
+            The points of the mesh.
+        """
+        return mesh.sample(num_points)
+
+    @staticmethod
+    def uniform_surface_sampling(mesh: trimesh.Trimesh, num_points: int) -> np.ndarray:
+        """Extracts the points of a mesh by sampling the surface of the mesh uniformly.
+
+        Args:
+            mesh: The mesh to extract the points from.
+            num_points: The number of points to sample.
+
+        Returns:
+            The points of the mesh.
+        """
+        return trimesh.sample.sample_surface_even(mesh=mesh, count=num_points)
+
+    @staticmethod
+    def aap(
+        mesh: trimesh.Trimesh,
+        axis: str,
+        direction: str,
+        aap_value: float,
+    ) -> np.ndarray:
+        """Axis Aligned Plane
+        Extracts the points of a mesh that are on one side of an axis-aligned plane (AAP).
+        This means that the algorithm considers all points above/below a certain value along one axis.
+
+        Args:
+            mesh: The mesh to extract the points from.
+            axis: The axis of the AAP.
+            direction: The direction of the AAP.
+            aap_value: The value of the AAP.
+
+        Returns:
+            The points of the mesh that are on one side of the AAP.
+
+        TODO: Implement inclined plane
+        """
+        if direction == "higher":
+            aap_operator = np.greater
+        elif direction == "lower":
+            aap_operator = np.less
+        else:
+            raise ValueError("Invalid direction for axis-aligned plane")
+
+        if axis == "x":
+            points = mesh.vertices[aap_operator(mesh.vertices[:, 0], aap_value)]
+        elif axis == "y":
+            points = mesh.vertices[aap_operator(mesh.vertices[:, 1], aap_value)]
+        elif axis == "z":
+            points = mesh.vertices[aap_operator(mesh.vertices[:, 2], aap_value)]
+        else:
+            raise ValueError("Invalid axis for axis-aligned plane")
+
+        return points
+
+    @staticmethod
+    def select_points_over_axis(
+        mesh: trimesh.Trimesh,
+        axis: str,
+        direction: str,
+        n: int,
+    ):
+        """Select Points Over Axis.
+        Select N points over an axis, either starting from the lower or higher end.
+
+        Args:
+            mesh: The mesh to extract the points from.
+            axis: The axis along which to remove points.
+            direction: The direction of the AAP.
+            n: The number of points to remove.
+
+        Returns:
+            The points of the mesh.
+        """
+        valid_dirs = ["higher", "lower"]
+        if direction not in valid_dirs:
+            raise ValueError(f"Invalid direction. Valid directions are {valid_dirs}")
+        arr = mesh.vertices
+
+        index = 0 if axis == "x" else 1 if axis == "y" else 2
+        # Sort the array in ascending order
+        sorted_arr = arr[arr[:, index].argsort()]
+
+        if direction == "lower":
+            # Select first N points
+            points = sorted_arr[:n]
+        elif direction == "higher":
+            # Select last N points
+            points = sorted_arr[-n:]
+        else:
+            raise ValueError(
+                f"Invalid direction {direction} for SelectPointsOverAxis method"
+            )
+
+        return points
+
+    @staticmethod
+    def object_mapping(
+        mesh: trimesh.Trimesh,
+        object: trimesh.Trimesh,
+        method: str = "subtraction",
+        **kwargs,
+    ):
+        """Object Mapping.
+        Removes points from a mesh that are inside another object, using subtraction or intersection.
+        The method can be either "subtraction" or "intersection".
+        The object can be a mesh or a primitive.
+
+        Args:
+            mesh: The mesh to extract the points from.
+            object: The object to use for mapping.
+            method: The method to use for mapping.
+            **kwargs: Additional arguments for the method.
+
+        Returns:
+            The points of the mesh.
+        """
+        if method == "subtraction":
+            x: trimesh.Trimesh = mesh.difference(object, **kwargs)
+            x.show()
+            points = x.vertices
+        elif method == "intersection":
+            points = mesh.intersection(object, **kwargs).vertices
+        else:
+            raise ValueError("Invalid method for object mapping")
+
+        return points
+
+    @staticmethod
+    def mesh_decimation(
+        mesh: trimesh.Trimesh,
+        method: str = "",
+        nsamples: int = -1,
+    ):
+        """Object decimation algorithm to reduce the number of vertices in a mesh, then extract points.
+
+        Args:
+            mesh: The mesh to extract the points from.
+            method: The method to use for decimation.
+            nsamples: The number of desired samples.
+
+        Returns:
+            The points of the mesh.
+        """
+
+        if method == "quadric":
+            mesh = mesh.simplify_quadric_decimation(nsamples // 3)
+        else:
+            raise ValueError("Invalid method for mesh decimation")
+
+        return mesh.vertices

--- a/src/jaxsim/parsers/rod/meshes.py
+++ b/src/jaxsim/parsers/rod/meshes.py
@@ -68,7 +68,7 @@ class MeshMapping:
     def aap(
         mesh: trimesh.Trimesh,
         axis: str,
-        direction: str,
+        operator: str,
         aap_value: float,
     ) -> np.ndarray:
         """Axis Aligned Plane
@@ -86,12 +86,23 @@ class MeshMapping:
 
         TODO: Implement inclined plane
         """
-        if direction == "higher":
-            aap_operator = np.greater
-        elif direction == "lower":
-            aap_operator = np.less
-        else:
-            raise ValueError("Invalid direction for axis-aligned plane")
+        valid_methods = [">", "<", ">=", "<="]
+        if operator not in valid_methods:
+            raise ValueError(
+                f"Invalid method {operator} for AAP. Valid methods are {valid_methods}"
+            )
+
+        match (operator):
+            case ">":
+                aap_operator = np.greater
+            case "<":
+                aap_operator = np.less
+            case ">=":
+                aap_operator = np.greater_equal
+            case "<=":
+                aap_operator = np.less_equal
+            case _:
+                raise ValueError(f"Invalid method {operator} for AAP")
 
         if axis == "x":
             points = mesh.vertices[aap_operator(mesh.vertices[:, 0], aap_value)]

--- a/src/jaxsim/parsers/rod/parser.py
+++ b/src/jaxsim/parsers/rod/parser.py
@@ -330,6 +330,7 @@ def extract_model_data(
                     collision=collision,
                     link_description=links_dict[link.name],
                     method=utils.MeshMappingMethods.UniformSurfaceSampling,
+                    nsamples=200,
                 )
                 if mesh_collision is not None:
                     collisions.append(mesh_collision)

--- a/src/jaxsim/parsers/rod/parser.py
+++ b/src/jaxsim/parsers/rod/parser.py
@@ -329,8 +329,9 @@ def extract_model_data(
                 mesh_collision = utils.create_mesh_collision(
                     collision=collision,
                     link_description=links_dict[link.name],
-                    method=utils.MeshMappingMethods.UniformSurfaceSampling,
-                    nsamples=200,
+                    method=utils.meshes.SelectPointsOverAxis(
+                        axis="z", direction="lower", n=50
+                    ),
                 )
                 if mesh_collision is not None:
                     collisions.append(mesh_collision)

--- a/src/jaxsim/parsers/rod/utils.py
+++ b/src/jaxsim/parsers/rod/utils.py
@@ -7,12 +7,14 @@ import numpy.typing as npt
 import rod
 import trimesh
 from rod.utils.resolve_uris import resolve_local_uri
+from typing import Tuple
 
 import jaxsim.typing as jtp
 from jaxsim import logging
 from jaxsim.math.adjoint import Adjoint
 from jaxsim.math.inertia import Inertia
 from jaxsim.parsers import descriptions
+from jaxsim.parsers.rod import meshes
 
 
 @enum.unique
@@ -21,9 +23,8 @@ class MeshMappingMethods(enum.IntEnum):
     RandomSurfaceSampling = enum.auto()  # Sample the surface of the mesh randomly
     UniformSurfaceSampling = enum.auto()  # Sample the surface of the mesh uniformly
     MeshDecimation = enum.auto()  # Decimate the mesh to a certain number of vertices
-    AxisAlignedBoundingBox = enum.auto()  # Subtraction of bounding box from mesh
+    MeshMapping = enum.auto()  # Subtraction of bounding box from mesh
     AxisAlignedPlane = enum.auto()  # Remove all points above a certain axis value
-
 
 
 def from_sdf_inertial(inertial: rod.Inertial) -> jtp.Matrix:
@@ -226,7 +227,9 @@ def create_mesh_collision(
     link_description: descriptions.LinkDescription,
     method: MeshMappingMethods = MeshMappingMethods.VertexExtraction,
     nsamples: int = 1000,
-    decimation_object: trimesh.Trimesh |  = None,
+    aap_axis: str = "z",
+    aap_value: float = 0.0,
+    aap_direction: str = "lower",
 ) -> descriptions.MeshCollision:
     file = pathlib.Path(resolve_local_uri(uri=collision.geometry.mesh.uri))
     _file_type = file.suffix.replace(".", "")
@@ -244,17 +247,26 @@ def create_mesh_collision(
     # Extract the points from the mesh to use as colliders according to the provided method
     match method:
         case MeshMappingMethods.VertexExtraction:
-            points = mesh.vertices
+            points = meshes.extract_points_vertex_extraction(mesh=mesh)
         case MeshMappingMethods.RandomSurfaceSampling:
-            points = mesh.sample(nsamples)
+            points = meshes.extract_points_random_surface_sampling(
+                mesh=mesh, num_points=nsamples
+            )
         case MeshMappingMethods.UniformSurfaceSampling:
-            points = trimesh.sample.sample_surface_even(mesh=mesh, count=nsamples)
+            points = meshes.extract_points_uniform_surface_sampling(
+                mesh=mesh, num_points=nsamples
+            )
         case MeshMappingMethods.MeshDecimation:
             raise NotImplementedError("Mesh decimation is not implemented yet")
-        case MeshMappingMethods.AxisAlignedBoundingBox:
-            raise NotImplementedError("Axis aligned bounding box is not implemented yet")
+        case MeshMappingMethods.MeshMapping:
+            raise NotImplementedError("AABMapping is not implemented yet")
         case MeshMappingMethods.AxisAlignedPlane:
-            raise NotImplementedError("Axis aligned plane is not implemented yet")
+            points = meshes.extract_points_aap(
+                mesh=mesh,
+                aap_axis=aap_axis,
+                aap_value=aap_value,
+                aap_direction=aap_direction,
+            )
         case _:
             raise ValueError("Invalid mesh mapping method")
 

--- a/src/jaxsim/parsers/rod/utils.py
+++ b/src/jaxsim/parsers/rod/utils.py
@@ -251,6 +251,10 @@ def create_mesh_collision(
             points = trimesh.sample.sample_surface_even(mesh=mesh, count=nsamples)
         case MeshMappingMethods.MeshDecimation:
             raise NotImplementedError("Mesh decimation is not implemented yet")
+        case MeshMappingMethods.AxisAlignedBoundingBox:
+            raise NotImplementedError("Axis aligned bounding box is not implemented yet")
+        case MeshMappingMethods.AxisAlignedPlane:
+            raise NotImplementedError("Axis aligned plane is not implemented yet")
         case _:
             raise ValueError("Invalid mesh mapping method")
 

--- a/src/jaxsim/parsers/rod/utils.py
+++ b/src/jaxsim/parsers/rod/utils.py
@@ -1,4 +1,3 @@
-import enum
 import os
 import pathlib
 
@@ -6,8 +5,9 @@ import numpy as np
 import numpy.typing as npt
 import rod
 import trimesh
+import inspect
 from rod.utils.resolve_uris import resolve_local_uri
-from typing import Tuple
+
 
 import jaxsim.typing as jtp
 from jaxsim import logging
@@ -15,19 +15,6 @@ from jaxsim.math.adjoint import Adjoint
 from jaxsim.math.inertia import Inertia
 from jaxsim.parsers import descriptions
 from jaxsim.parsers.rod import meshes
-
-
-@enum.unique
-class MeshMappingMethods(enum.IntEnum):
-    VertexExtraction = enum.auto()  # Use the vertices of the mesh as colliders
-    RandomSurfaceSampling = enum.auto()  # Sample the surface of the mesh randomly
-    UniformSurfaceSampling = enum.auto()  # Sample the surface of the mesh uniformly
-    MeshDecimation = enum.auto()  # Decimate the mesh to a certain number of vertices
-    ObjectMapping = enum.auto()  # Subtraction of bounding box from mesh
-    AxisAlignedPlane = enum.auto()  # Remove all points above a certain axis value
-    SelectPointsOverAxis = (
-        enum.auto()
-    )  # Remove N highest or lowest points over a certain axis value
 
 
 def from_sdf_inertial(inertial: rod.Inertial) -> jtp.Matrix:
@@ -228,14 +215,15 @@ def create_sphere_collision(
 def create_mesh_collision(
     collision: rod.Collision,
     link_description: descriptions.LinkDescription,
-    method: MeshMappingMethods = MeshMappingMethods.VertexExtraction,
+    method: meshes.MeshMappingMethod = meshes.VertexExtraction(),
     nsamples: int = 1000,
     axis: str = "z",
     direction: str = "lower",
-    aap_operator: str = "<",
-    aap_value: float = 0.0,
-    object_mapping_object: trimesh.Trimesh | dict = None,
+    operator: str = "<",
+    value: float = 0.0,
+    obj: trimesh.Trimesh | dict = None,
 ) -> descriptions.MeshCollision:
+
     file = pathlib.Path(resolve_local_uri(uri=collision.geometry.mesh.uri))
     _file_type = file.suffix.replace(".", "")
     mesh = trimesh.load_mesh(file, file_type=_file_type)
@@ -250,55 +238,8 @@ def create_mesh_collision(
     )
 
     # Extract the points from the mesh to use as colliders according to the provided method
-    match method:
-        case MeshMappingMethods.VertexExtraction:
-            points = meshes.MeshMapping.vertex_extraction(mesh=mesh)
-        case MeshMappingMethods.RandomSurfaceSampling:
-            if nsamples > len(mesh.vertices):
-                logging.warning(
-                    f"Number of samples {nsamples} is larger than the number of vertices {len(mesh.vertices)} in the mesh. Falling back to number of vertices"
-                )
-                nsamples = len(mesh.vertices)
-            points = meshes.MeshMapping.random_surface_sampling(
-                mesh=mesh, num_points=nsamples
-            )
-        case MeshMappingMethods.UniformSurfaceSampling:
-            if nsamples > len(mesh.vertices):
-                logging.warning(
-                    f"Number of samples {nsamples} is larger than the number of vertices {len(mesh.vertices)} in the mesh. Falling back to number of vertices"
-                )
-                nsamples = len(mesh.vertices)
-            points = meshes.MeshMapping.uniform_surface_sampling(
-                mesh=mesh, num_points=nsamples
-            )
-        case MeshMappingMethods.MeshDecimation:
-            raise NotImplementedError("Mesh decimation is not implemented yet")
-        case MeshMappingMethods.ObjectMapping:
-            if object_mapping_object is None:
-                raise ValueError("Object mapping object was not provided")
-            obj = meshes.parse_object_mapping_object(object_mapping_object)
-            points = meshes.MeshMapping.object_mapping(mesh=mesh, object=obj)
-        case MeshMappingMethods.AxisAlignedPlane:
-            points = meshes.MeshMapping.aap(
-                mesh=mesh,
-                axis=axis,
-                operator=aap_operator,
-                aap_value=aap_value,
-            )
-        case MeshMappingMethods.SelectPointsOverAxis:
-            if nsamples > len(mesh.vertices):
-                logging.warning(
-                    f"Number of samples {nsamples} is larger than the number of vertices {len(mesh.vertices)} in the mesh. Falling back to number of vertices"
-                )
-                nsamples = len(mesh.vertices)
-            points = meshes.MeshMapping.select_points_over_axis(
-                mesh=mesh,
-                axis=axis,
-                direction=direction,
-                n=nsamples,
-            )
-        case _:
-            raise ValueError("Invalid mesh mapping method")
+    if method is not None:
+        points = method(mesh=mesh)
 
     points = mesh.vertices
     H = collision.pose.transform() if collision.pose is not None else np.eye(4)

--- a/src/jaxsim/parsers/rod/utils.py
+++ b/src/jaxsim/parsers/rod/utils.py
@@ -232,6 +232,7 @@ def create_mesh_collision(
     nsamples: int = 1000,
     axis: str = "z",
     direction: str = "lower",
+    aap_operator: str = "<",
     aap_value: float = 0.0,
     object_mapping_object: trimesh.Trimesh | dict = None,
 ) -> descriptions.MeshCollision:
@@ -281,7 +282,7 @@ def create_mesh_collision(
             points = meshes.MeshMapping.aap(
                 mesh=mesh,
                 axis=axis,
-                direction=direction,
+                operator=aap_operator,
                 aap_value=aap_value,
             )
         case MeshMappingMethods.SelectPointsOverAxis:

--- a/src/jaxsim/parsers/rod/utils.py
+++ b/src/jaxsim/parsers/rod/utils.py
@@ -17,9 +17,13 @@ from jaxsim.parsers import descriptions
 
 @enum.unique
 class MeshMappingMethods(enum.IntEnum):
-    VertexExtraction = enum.auto()
-    RandomSurfaceSampling = enum.auto()
-    UniformSurfaceSampling = enum.auto()
+    VertexExtraction = enum.auto()  # Use the vertices of the mesh as colliders
+    RandomSurfaceSampling = enum.auto()  # Sample the surface of the mesh randomly
+    UniformSurfaceSampling = enum.auto()  # Sample the surface of the mesh uniformly
+    MeshDecimation = enum.auto()  # Decimate the mesh to a certain number of vertices
+    AxisAlignedBoundingBox = enum.auto()  # Subtraction of bounding box from mesh
+    AxisAlignedPlane = enum.auto()  # Remove all points above a certain axis value
+
 
 
 def from_sdf_inertial(inertial: rod.Inertial) -> jtp.Matrix:
@@ -222,6 +226,7 @@ def create_mesh_collision(
     link_description: descriptions.LinkDescription,
     method: MeshMappingMethods = MeshMappingMethods.VertexExtraction,
     nsamples: int = 1000,
+    decimation_object: trimesh.Trimesh |  = None,
 ) -> descriptions.MeshCollision:
     file = pathlib.Path(resolve_local_uri(uri=collision.geometry.mesh.uri))
     _file_type = file.suffix.replace(".", "")
@@ -244,6 +249,8 @@ def create_mesh_collision(
             points = mesh.sample(nsamples)
         case MeshMappingMethods.UniformSurfaceSampling:
             points = trimesh.sample.sample_surface_even(mesh=mesh, count=nsamples)
+        case MeshMappingMethods.MeshDecimation:
+            raise NotImplementedError("Mesh decimation is not implemented yet")
         case _:
             raise ValueError("Invalid mesh mapping method")
 

--- a/src/jaxsim/parsers/rod/utils.py
+++ b/src/jaxsim/parsers/rod/utils.py
@@ -23,8 +23,11 @@ class MeshMappingMethods(enum.IntEnum):
     RandomSurfaceSampling = enum.auto()  # Sample the surface of the mesh randomly
     UniformSurfaceSampling = enum.auto()  # Sample the surface of the mesh uniformly
     MeshDecimation = enum.auto()  # Decimate the mesh to a certain number of vertices
-    MeshMapping = enum.auto()  # Subtraction of bounding box from mesh
+    ObjectMapping = enum.auto()  # Subtraction of bounding box from mesh
     AxisAlignedPlane = enum.auto()  # Remove all points above a certain axis value
+    SelectPointsOverAxis = (
+        enum.auto()
+    )  # Remove N highest or lowest points over a certain axis value
 
 
 def from_sdf_inertial(inertial: rod.Inertial) -> jtp.Matrix:
@@ -227,9 +230,10 @@ def create_mesh_collision(
     link_description: descriptions.LinkDescription,
     method: MeshMappingMethods = MeshMappingMethods.VertexExtraction,
     nsamples: int = 1000,
-    aap_axis: str = "z",
+    axis: str = "z",
+    direction: str = "lower",
     aap_value: float = 0.0,
-    aap_direction: str = "lower",
+    object_mapping_object: trimesh.Trimesh | dict = None,
 ) -> descriptions.MeshCollision:
     file = pathlib.Path(resolve_local_uri(uri=collision.geometry.mesh.uri))
     _file_type = file.suffix.replace(".", "")
@@ -247,25 +251,50 @@ def create_mesh_collision(
     # Extract the points from the mesh to use as colliders according to the provided method
     match method:
         case MeshMappingMethods.VertexExtraction:
-            points = meshes.extract_points_vertex_extraction(mesh=mesh)
+            points = meshes.MeshMapping.vertex_extraction(mesh=mesh)
         case MeshMappingMethods.RandomSurfaceSampling:
-            points = meshes.extract_points_random_surface_sampling(
+            if nsamples > len(mesh.vertices):
+                logging.warning(
+                    f"Number of samples {nsamples} is larger than the number of vertices {len(mesh.vertices)} in the mesh. Falling back to number of vertices"
+                )
+                nsamples = len(mesh.vertices)
+            points = meshes.MeshMapping.random_surface_sampling(
                 mesh=mesh, num_points=nsamples
             )
         case MeshMappingMethods.UniformSurfaceSampling:
-            points = meshes.extract_points_uniform_surface_sampling(
+            if nsamples > len(mesh.vertices):
+                logging.warning(
+                    f"Number of samples {nsamples} is larger than the number of vertices {len(mesh.vertices)} in the mesh. Falling back to number of vertices"
+                )
+                nsamples = len(mesh.vertices)
+            points = meshes.MeshMapping.uniform_surface_sampling(
                 mesh=mesh, num_points=nsamples
             )
         case MeshMappingMethods.MeshDecimation:
             raise NotImplementedError("Mesh decimation is not implemented yet")
-        case MeshMappingMethods.MeshMapping:
-            raise NotImplementedError("AABMapping is not implemented yet")
+        case MeshMappingMethods.ObjectMapping:
+            if object_mapping_object is None:
+                raise ValueError("Object mapping object was not provided")
+            obj = meshes.parse_object_mapping_object(object_mapping_object)
+            points = meshes.MeshMapping.object_mapping(mesh=mesh, object=obj)
         case MeshMappingMethods.AxisAlignedPlane:
-            points = meshes.extract_points_aap(
+            points = meshes.MeshMapping.aap(
                 mesh=mesh,
-                aap_axis=aap_axis,
+                axis=axis,
+                direction=direction,
                 aap_value=aap_value,
-                aap_direction=aap_direction,
+            )
+        case MeshMappingMethods.SelectPointsOverAxis:
+            if nsamples > len(mesh.vertices):
+                logging.warning(
+                    f"Number of samples {nsamples} is larger than the number of vertices {len(mesh.vertices)} in the mesh. Falling back to number of vertices"
+                )
+                nsamples = len(mesh.vertices)
+            points = meshes.MeshMapping.select_points_over_axis(
+                mesh=mesh,
+                axis=axis,
+                direction=direction,
+                n=nsamples,
             )
         case _:
             raise ValueError("Invalid mesh mapping method")

--- a/tests/test_meshes.py
+++ b/tests/test_meshes.py
@@ -37,22 +37,23 @@ def test_mesh_wrapping_aap():
     mesh = trimesh.creation.box(
         extents=[3.0, 3.0, 3.0],
     )
-    points = meshes.MeshMapping.aap(mesh, axis="x", aap_value=0.0, direction="higher")
+    points = meshes.MeshMapping.aap(mesh, axis="x", aap_value=0.0, operator=">")
     assert len(points) == len(mesh.vertices) // 2
     assert all(points[:, 0] > 0.0)
 
     # Test 1.2: Remove all points below y=0.0
     # Again, the expected result is that the number of points is halved
-    points = meshes.MeshMapping.aap(mesh, axis="y", aap_value=0.0, direction="lower")
+    points = meshes.MeshMapping.aap(mesh, axis="y", aap_value=0.0, operator="<")
     assert len(points) == len(mesh.vertices) // 2
     assert all(points[:, 1] < 0.0)
 
     # Test 2: A sphere
-    # The sphere is centered at the origin and has a radius of 1.0
+    # The sphere is centered at the origin and has a radius of 1.0. Points are expected to be halved
     mesh = trimesh.creation.icosphere(subdivisions=4, radius=1.0)
     # Remove all points above y=0.0
-    points = meshes.MeshMapping.aap(mesh, axis="y", aap_value=0.0, direction="higher")
-    assert all(points[:, 1] > 0.0)
+    points = meshes.MeshMapping.aap(mesh, axis="y", aap_value=0.0, operator=">=")
+    assert all(points[:, 1] >= 0.0)
+    assert len(points) < len(mesh.vertices)
 
 
 def test_mesh_wrapping_points_over_axis():

--- a/tests/test_meshes.py
+++ b/tests/test_meshes.py
@@ -1,7 +1,26 @@
-import pytest
-import tempfile
 import trimesh
 from jaxsim.parsers.rod import meshes
+
+
+def test_mesh_wrapping_vertex_extraction():
+    """Test the vertex extraction method on different meshes.
+    1. A simple box
+    2. A sphere
+    """
+
+    # Test 1: A simple box
+    # First, create a box with origin at (0,0,0) and extents (3,3,3) -> points span from -1.5 to 1.5 on axis
+    mesh = trimesh.creation.box(
+        extents=[3.0, 3.0, 3.0],
+    )
+    points = meshes.MeshMapping.vertex_extraction(mesh)
+    assert len(points) == len(mesh.vertices)
+
+    # Test 2: A sphere
+    # The sphere is centered at the origin and has a radius of 1.0
+    mesh = trimesh.creation.icosphere(subdivisions=4, radius=1.0)
+    points = meshes.MeshMapping.vertex_extraction(mesh)
+    assert len(points) == len(mesh.vertices)
 
 
 def test_mesh_wrapping_aap():
@@ -18,17 +37,13 @@ def test_mesh_wrapping_aap():
     mesh = trimesh.creation.box(
         extents=[3.0, 3.0, 3.0],
     )
-    points = meshes.extract_points_aap(
-        mesh, aap_axis="x", aap_value=0.0, aap_direction="higher"
-    )
+    points = meshes.MeshMapping.aap(mesh, axis="x", aap_value=0.0, direction="higher")
     assert len(points) == len(mesh.vertices) // 2
     assert all(points[:, 0] > 0.0)
 
     # Test 1.2: Remove all points below y=0.0
     # Again, the expected result is that the number of points is halved
-    points = meshes.extract_points_aap(
-        mesh, aap_axis="y", aap_value=0.0, aap_direction="lower"
-    )
+    points = meshes.MeshMapping.aap(mesh, axis="y", aap_value=0.0, direction="lower")
     assert len(points) == len(mesh.vertices) // 2
     assert all(points[:, 1] < 0.0)
 
@@ -36,7 +51,77 @@ def test_mesh_wrapping_aap():
     # The sphere is centered at the origin and has a radius of 1.0
     mesh = trimesh.creation.icosphere(subdivisions=4, radius=1.0)
     # Remove all points above y=0.0
-    points = meshes.extract_points_aap(
-        mesh, aap_axis="y", aap_value=0.0, aap_direction="higher"
-    )
+    points = meshes.MeshMapping.aap(mesh, axis="y", aap_value=0.0, direction="higher")
     assert all(points[:, 1] > 0.0)
+
+
+def test_mesh_wrapping_points_over_axis():
+    """Test the points over axis method on different meshes.
+    1. A simple box
+        1.1: Select 10 points from the lower end of the x-axis
+        1.2: Select 10 points from the higher end of the y-axis
+    2. A sphere
+    """
+
+    # Test 1.1: Remove 10 points from the lower end of the x-axis
+    # First, create a box with origin at (0,0,0) and extents (3,3,3) -> points span from -1.5 to 1.5 on axis
+    mesh = trimesh.creation.box(
+        extents=[3.0, 3.0, 3.0],
+    )
+    points = meshes.MeshMapping.select_points_over_axis(
+        mesh, axis="x", direction="lower", n=4
+    )
+    assert len(points) == 4
+    assert all(points[:, 0] < 0.0)
+
+    # Test 1.2: Select 10 points from the higher end of the y-axis
+    points = meshes.MeshMapping.select_points_over_axis(
+        mesh, axis="y", direction="higher", n=4
+    )
+    assert len(points) == 4
+    assert all(points[:, 1] > 0.0)
+
+    # Test 2: A sphere
+    # The sphere is centered at the origin and has a radius of 1.0
+    mesh = trimesh.creation.icosphere(subdivisions=4, radius=1.0)
+    sphere_n_vertices = len(mesh.vertices)
+
+    # Select 10 points from the higher end of the z-axis
+    points = meshes.MeshMapping.select_points_over_axis(
+        mesh, axis="z", direction="higher", n=sphere_n_vertices // 2
+    )
+    assert len(points) == sphere_n_vertices // 2
+    assert all(points[:, 2] >= 0.0)
+
+
+def test_mesh_wrapping_object_mapping():
+    """Test the object mapping method on different meshes.
+    1. Subtract a box from a sphere
+    2. Subtract a sphere from a bigger sphere
+    3. Subtract a small box from a bigger box to remove the right-top corner of the first box
+    """
+
+    return  # Skip this test for now
+
+    # Test 1: Subtract a box from a sphere
+    sphere = trimesh.creation.icosphere(subdivisions=4, radius=1.0)
+    box = trimesh.creation.box(extents=[0.5, 0.5, 0.5])
+    points = meshes.MeshMapping.object_mapping(sphere, box, method="subtraction")
+    assert len(points) < len(sphere.vertices)
+
+    # Test 2: Subtract a sphere from a bigger sphere
+    sphere1 = trimesh.creation.icosphere(subdivisions=4, radius=1.5)
+    sphere2 = trimesh.creation.icosphere(subdivisions=4, radius=1.0)
+    points = meshes.MeshMapping.object_mapping(sphere1, sphere2, method="subtraction")
+    assert len(points) < len(sphere1.vertices)
+    assert len(points) > len(sphere2.vertices)
+
+    # Test 3: Subtract a small box from a bigger box to remove the right-top corner of the first box
+    box1 = trimesh.creation.box(extents=[3.0, 3.0, 3.0])
+    box2 = trimesh.creation.box(
+        extents=[1.0, 1.0, 1.0],
+        transform=trimesh.transformations.translation_matrix([1.5, 1.5, 1.5]),
+    )
+    points = meshes.MeshMapping.object_mapping(box1, box2, method="subtraction")
+    assert len(points) < len(box1)
+    assert len(points) == 7

--- a/tests/test_meshes.py
+++ b/tests/test_meshes.py
@@ -1,0 +1,42 @@
+import pytest
+import tempfile
+import trimesh
+from jaxsim.parsers.rod import meshes
+
+
+def test_mesh_wrapping_aap():
+    """Test the AAP wrapping method on different meshes.
+    1. A simple box
+        1.1: Remove all points above x=0.0
+        1.2: Remove all points below y=0.0
+    2. A sphere
+    """
+
+    # Test 1.1: Remove all points above x=0.0
+    # The expected result is that the number of points is halved
+    # First, create a box with origin at (0,0,0) and extents (3,3,3) -> points span from -1.5 to 1.5 on axis
+    mesh = trimesh.creation.box(
+        extents=[3.0, 3.0, 3.0],
+    )
+    points = meshes.extract_points_aap(
+        mesh, aap_axis="x", aap_value=0.0, aap_direction="higher"
+    )
+    assert len(points) == len(mesh.vertices) // 2
+    assert all(points[:, 0] > 0.0)
+
+    # Test 1.2: Remove all points below y=0.0
+    # Again, the expected result is that the number of points is halved
+    points = meshes.extract_points_aap(
+        mesh, aap_axis="y", aap_value=0.0, aap_direction="lower"
+    )
+    assert len(points) == len(mesh.vertices) // 2
+    assert all(points[:, 1] < 0.0)
+
+    # Test 2: A sphere
+    # The sphere is centered at the origin and has a radius of 1.0
+    mesh = trimesh.creation.icosphere(subdivisions=4, radius=1.0)
+    # Remove all points above y=0.0
+    points = meshes.extract_points_aap(
+        mesh, aap_axis="y", aap_value=0.0, aap_direction="higher"
+    )
+    assert all(points[:, 1] > 0.0)


### PR DESCRIPTION
Currently the only supported mesh wrapping algorithms either extract too many points, or do not give enough control over mesh reduction. These algorithms are currently:

- Vertex extraction: use mesh vertices as collidable points
- Random surface sampling (N: int = number of samples): Randomly sample N points from the mesh surface
- Uniform surface sampling (N: int = number of samples): Uniformly sample N points from the mesh surface

New mesh extraction algorithms include:
- Mesh decimation: automatically reduce the number of triangles on a mesh to a given value
- Axis Aligned Box Mapping: subtract other shapes over the considered mesh to remove vertices
- Axis Aligned Plane: Remove all vertices above or below a certain value over a specified axis.